### PR TITLE
[SCV-2784] Support "provider" field for AWS S3 assets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,7 +5,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=terraform-providers
 PKG_NAME=dsfhub
 BINARY=terraform-provider-${PKG_NAME}
-VERSION=1.2.42
+VERSION=1.2.43
 OS_ARCH=darwin_amd64
 
 default: install

--- a/dsfhub/client.go
+++ b/dsfhub/client.go
@@ -130,7 +130,7 @@ type AssetData struct {
 	OwnedBy                string      `json:"owned_by,omitempty"`
 	ParentAssetID          string      `json:"parent_asset_id,omitempty"`
 	Project                string      `json:"project,omitempty"`
-	ADProvider             string      `json:"provider,omitempty"`
+	S3Provider             string      `json:"provider,omitempty"`
 	ProviderUrl            string      `json:"provider_url,omitempty"`
 	Proxy                  string      `json:"proxy,omitempty"`
 	PubsubSubscription     string      `json:"pubsub_subscription,omitempty"`

--- a/dsfhub/client_log_aggregator.go
+++ b/dsfhub/client_log_aggregator.go
@@ -31,7 +31,7 @@ func (c *Client) CreateLogAggregator(logAggregator ResourceWrapper) (*ResourceWr
 	responseBody, err := ioutil.ReadAll(resp.Body)
 
 	// Dump JSON
-	log.Printf("[DEBUG] Add CloudAccount JSON response: %s\n", string(responseBody))
+	log.Printf("[DEBUG] Add LogAggregator JSON response: %s\n", string(responseBody))
 
 	// Parse the JSON
 	var createLogAggregatorResponse ResourceWrapper

--- a/dsfhub/resource_asset_schema.go
+++ b/dsfhub/resource_asset_schema.go
@@ -1605,16 +1605,16 @@ var assetSchemaJson = `{
             "required": true,
             "type": "string"
         },
-        "ProvIDer": {
+        "S3Provider": {
             "defaultValue": "aws-rds-mssql",
             "description": "The type of AWS RDS instance that the S3 asset is receiving audit logs from",
             "displayName": "Provider",
             "example": "aws-rds-mssql",
-            "id": "provider",
+            "id": "s3_provider",
             "required": false,
             "type": "string"
         },
-        "ProvIDerUrl": {
+        "ProviderUrl": {
             "defaultValue": null,
             "description": "",
             "displayName": "Provider URL",

--- a/dsfhub/resource_data_source.go
+++ b/dsfhub/resource_data_source.go
@@ -1137,13 +1137,6 @@ func resourceDSFDataSource() *schema.Resource {
 				Optional:    true,
 				Default:     nil,
 			},
-			"ad_provider": {
-				Type:        schema.TypeString,
-				Description: "The type of AWS RDS instance that the S3 asset is receiving audit logs from",
-				Required:    false,
-				Optional:    true,
-				Default:     nil,
-			},
 			"provider_url": {
 				Type:        schema.TypeString,
 				Description: "",

--- a/dsfhub/resource_log_aggregator.go
+++ b/dsfhub/resource_log_aggregator.go
@@ -542,6 +542,13 @@ func resourceLogAggregator() *schema.Resource {
 				Optional:    true,
 				Default:     nil,
 			},
+			"s3_provider": {
+				Type:        schema.TypeString,
+				Description: "Accepted value: \"aws-rds-mssql\", required only for AWS RDS MS SQL SERVER auditing workflow.",
+				Required:    false,
+				Optional:    true,
+				Default:     nil,
+			},
 			"server_host_name": {
 				Type:        schema.TypeString,
 				Description: "Hostname (or IP if name is unknown)",
@@ -691,6 +698,7 @@ func resourceLogAggregatorRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("proxy", logAggregatorReadResponse.Data.AssetData.Proxy)
 	d.Set("pubsub_subscription", logAggregatorReadResponse.Data.AssetData.PubsubSubscription)
 	d.Set("region", logAggregatorReadResponse.Data.AssetData.Region)
+	d.Set("s3_provider", logAggregatorReadResponse.Data.AssetData.S3Provider)
 	d.Set("server_host_name", logAggregatorReadResponse.Data.AssetData.ServerHostName)
 	d.Set("server_type", logAggregatorReadResponse.Data.ServerType)
 	if logAggregatorReadResponse.Data.AssetData.ServerPort != nil {

--- a/examples/data_sources/aerospike.md
+++ b/examples/data_sources/aerospike.md
@@ -68,7 +68,6 @@ resource "dsfhub_data_source" "example_aerospike" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/alibaba_apsara_mongodb.md
+++ b/examples/data_sources/alibaba_apsara_mongodb.md
@@ -81,7 +81,6 @@ resource "dsfhub_data_source" "example_alibaba_apsara_mongodb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/alibaba_apsara_rds_mysql.md
+++ b/examples/data_sources/alibaba_apsara_rds_mysql.md
@@ -74,7 +74,6 @@ resource "dsfhub_data_source" "example_alibaba_apsara_rds_mysql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/alibaba_apsara_rds_postgresql.md
+++ b/examples/data_sources/alibaba_apsara_rds_postgresql.md
@@ -74,7 +74,6 @@ resource "dsfhub_data_source" "example_alibaba_apsara_rds_postgresql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/alibaba_max_compute.md
+++ b/examples/data_sources/alibaba_max_compute.md
@@ -69,7 +69,6 @@ resource "dsfhub_data_source" "example_alibaba_max_compute" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/alibaba_oss.md
+++ b/examples/data_sources/alibaba_oss.md
@@ -69,7 +69,6 @@ resource "dsfhub_data_source" "example_alibaba_oss" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/ambari.md
+++ b/examples/data_sources/ambari.md
@@ -71,7 +71,6 @@ resource "dsfhub_data_source" "example_ambari" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_athena.md
+++ b/examples/data_sources/aws_athena.md
@@ -75,7 +75,6 @@ resource "dsfhub_data_source" "example_aws_athena" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_documentdb.md
+++ b/examples/data_sources/aws_documentdb.md
@@ -110,7 +110,6 @@ resource "dsfhub_data_source" "example_aws_documentdb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_documentdb_cluster.md
+++ b/examples/data_sources/aws_documentdb_cluster.md
@@ -110,7 +110,6 @@ resource "dsfhub_data_source" "example_aws_documentdb_cluster" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_dynamodb.md
+++ b/examples/data_sources/aws_dynamodb.md
@@ -113,7 +113,6 @@ resource "dsfhub_data_source" "example_aws_dynamodb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_glue.md
+++ b/examples/data_sources/aws_glue.md
@@ -77,7 +77,6 @@ resource "dsfhub_data_source" "example_aws_glue" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_lake_formation.md
+++ b/examples/data_sources/aws_lake_formation.md
@@ -77,7 +77,6 @@ resource "dsfhub_data_source" "example_aws_lake_formation" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_neptune.md
+++ b/examples/data_sources/aws_neptune.md
@@ -79,7 +79,6 @@ resource "dsfhub_data_source" "example_aws_neptune" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_neptune_cluster.md
+++ b/examples/data_sources/aws_neptune_cluster.md
@@ -79,7 +79,6 @@ resource "dsfhub_data_source" "example_aws_neptune_cluster" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_aurora_mysql.md
+++ b/examples/data_sources/aws_rds_aurora_mysql.md
@@ -80,7 +80,6 @@ resource "dsfhub_data_source" "example_aws_rds_aurora_mysql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_aurora_mysql_cluster.md
+++ b/examples/data_sources/aws_rds_aurora_mysql_cluster.md
@@ -91,7 +91,6 @@ resource "dsfhub_data_source" "example_aws_rds_aurora_mysql_cluster" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_aurora_postgresql.md
+++ b/examples/data_sources/aws_rds_aurora_postgresql.md
@@ -92,7 +92,6 @@ resource "dsfhub_data_source" "example_aws_rds_aurora_postgresql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_aurora_postgresql_cluster.md
+++ b/examples/data_sources/aws_rds_aurora_postgresql_cluster.md
@@ -97,7 +97,6 @@ resource "dsfhub_data_source" "example_aws_rds_aurora_postgresql_cluster" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_mariadb.md
+++ b/examples/data_sources/aws_rds_mariadb.md
@@ -79,7 +79,6 @@ resource "dsfhub_data_source" "example_aws_rds_mariadb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_ms_sql_server.md
+++ b/examples/data_sources/aws_rds_ms_sql_server.md
@@ -86,7 +86,6 @@ resource "dsfhub_data_source" "example_aws_rds_ms_sql_server" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_mysql.md
+++ b/examples/data_sources/aws_rds_mysql.md
@@ -233,7 +233,6 @@ resource "aws_iam_role_policy_attachment" "log_group_policy_attachment" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_oracle.md
+++ b/examples/data_sources/aws_rds_oracle.md
@@ -105,7 +105,6 @@ resource "dsfhub_data_source" "example_aws_rds_oracle" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_rds_postgresql.md
+++ b/examples/data_sources/aws_rds_postgresql.md
@@ -86,7 +86,6 @@ resource "dsfhub_data_source" "example_aws_rds_postgresql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_redshift.md
+++ b/examples/data_sources/aws_redshift.md
@@ -108,7 +108,6 @@ resource "dsfhub_data_source" "example_aws_redshift" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/aws_s3.md
+++ b/examples/data_sources/aws_s3.md
@@ -80,7 +80,6 @@ resource "dsfhub_data_source" "example_aws_s3" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_cosmosdb.md
+++ b/examples/data_sources/azure_cosmosdb.md
@@ -72,7 +72,6 @@ resource "dsfhub_data_source" "example_azure_cosmosdb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_cosmosdb_mongo.md
+++ b/examples/data_sources/azure_cosmosdb_mongo.md
@@ -72,7 +72,6 @@ resource "dsfhub_data_source" "example_azure_cosmosdb_mongo" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_cosmosdb_table.md
+++ b/examples/data_sources/azure_cosmosdb_table.md
@@ -73,7 +73,6 @@ resource "dsfhub_data_source" "example_azure_cosmosdb_table" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_mariadb.md
+++ b/examples/data_sources/azure_mariadb.md
@@ -74,7 +74,6 @@ resource "dsfhub_data_source" "example_azure_mariadb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_ms_sql_server.md
+++ b/examples/data_sources/azure_ms_sql_server.md
@@ -83,7 +83,6 @@ resource "dsfhub_data_source" "example_azure_ms_sql_server" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_mysql.md
+++ b/examples/data_sources/azure_mysql.md
@@ -74,7 +74,6 @@ resource "dsfhub_data_source" "example_azure_mysql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_postgresql.md
+++ b/examples/data_sources/azure_postgresql.md
@@ -82,7 +82,6 @@ resource "dsfhub_data_source" "example_azure_postgresql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_sql_managed_instance.md
+++ b/examples/data_sources/azure_sql_managed_instance.md
@@ -83,7 +83,6 @@ resource "dsfhub_data_source" "example_azure_sql_managed_instance" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/azure_storage_account.md
+++ b/examples/data_sources/azure_storage_account.md
@@ -71,7 +71,6 @@ resource "dsfhub_data_source" "example_azure_storage_account" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/cassandra.md
+++ b/examples/data_sources/cassandra.md
@@ -77,7 +77,6 @@ resource "dsfhub_data_source" "example_cassandra" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/cloudant.md
+++ b/examples/data_sources/cloudant.md
@@ -92,7 +92,6 @@ resource "dsfhub_data_source" "example_cloudant" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/cloudant_local.md
+++ b/examples/data_sources/cloudant_local.md
@@ -61,7 +61,6 @@ resource "dsfhub_data_source" "example_cloudant_local" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/cloudera.md
+++ b/examples/data_sources/cloudera.md
@@ -61,7 +61,6 @@ resource "dsfhub_data_source" "example_cloudera" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/cockroachdb.md
+++ b/examples/data_sources/cockroachdb.md
@@ -81,7 +81,6 @@ resource "dsfhub_data_source" "example_cockroachdb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/couchbase.md
+++ b/examples/data_sources/couchbase.md
@@ -74,7 +74,6 @@ resource "dsfhub_data_source" "example_couchbase" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/datastax.md
+++ b/examples/data_sources/datastax.md
@@ -77,7 +77,6 @@ resource "dsfhub_data_source" "example_datastax" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/db2.md
+++ b/examples/data_sources/db2.md
@@ -95,7 +95,6 @@ resource "dsfhub_data_source" "example_db2" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/edb_postgresql.md
+++ b/examples/data_sources/edb_postgresql.md
@@ -80,7 +80,6 @@ resource "dsfhub_data_source" "example_edb_postgresql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/elasticsearch.md
+++ b/examples/data_sources/elasticsearch.md
@@ -70,7 +70,6 @@ resource "dsfhub_data_source" "example_elasticsearch" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/eloquence.md
+++ b/examples/data_sources/eloquence.md
@@ -70,7 +70,6 @@ resource "dsfhub_data_source" "example_eloquence" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/emr.md
+++ b/examples/data_sources/emr.md
@@ -60,7 +60,6 @@ resource "dsfhub_data_source" "example_emr" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/gcp_bigquery.md
+++ b/examples/data_sources/gcp_bigquery.md
@@ -87,7 +87,6 @@ resource "dsfhub_data_source" "example_gcp_bigquery" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/gcp_bigtable.md
+++ b/examples/data_sources/gcp_bigtable.md
@@ -85,7 +85,6 @@ resource "dsfhub_data_source" "example_gcp_bigtable" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/gcp_ms_sql_server.md
+++ b/examples/data_sources/gcp_ms_sql_server.md
@@ -84,7 +84,6 @@ resource "dsfhub_data_source" "example_gcp_ms_sql_server" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/gcp_mysql.md
+++ b/examples/data_sources/gcp_mysql.md
@@ -81,7 +81,6 @@ resource "dsfhub_data_source" "example_gcp_mysql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/gcp_postgresql.md
+++ b/examples/data_sources/gcp_postgresql.md
@@ -85,7 +85,6 @@ resource "dsfhub_data_source" "example_gcp_postgresql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/gcp_spanner.md
+++ b/examples/data_sources/gcp_spanner.md
@@ -72,7 +72,6 @@ resource "dsfhub_data_source" "example_gcp_spanner" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/hbase.md
+++ b/examples/data_sources/hbase.md
@@ -101,7 +101,6 @@ resource "dsfhub_data_source" "example_hbase" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/hdfs.md
+++ b/examples/data_sources/hdfs.md
@@ -71,7 +71,6 @@ resource "dsfhub_data_source" "example_hdfs" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/hive.md
+++ b/examples/data_sources/hive.md
@@ -117,7 +117,6 @@ resource "dsfhub_data_source" "example_hive" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/hortonworks.md
+++ b/examples/data_sources/hortonworks.md
@@ -60,7 +60,6 @@ resource "dsfhub_data_source" "example_hortonworks" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/impala.md
+++ b/examples/data_sources/impala.md
@@ -102,7 +102,6 @@ resource "dsfhub_data_source" "example_impala" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/informix.md
+++ b/examples/data_sources/informix.md
@@ -72,7 +72,6 @@ resource "dsfhub_data_source" "example_informix" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/iris.md
+++ b/examples/data_sources/iris.md
@@ -78,7 +78,6 @@ resource "dsfhub_data_source" "example_iris" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/kinetica.md
+++ b/examples/data_sources/kinetica.md
@@ -77,7 +77,6 @@ resource "dsfhub_data_source" "example_kinetica" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/knox_gateway.md
+++ b/examples/data_sources/knox_gateway.md
@@ -71,7 +71,6 @@ resource "dsfhub_data_source" "example_knox_gateway" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/mariadb.md
+++ b/examples/data_sources/mariadb.md
@@ -72,7 +72,6 @@ resource "dsfhub_data_source" "example_mariadb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/marklogic.md
+++ b/examples/data_sources/marklogic.md
@@ -70,7 +70,6 @@ resource "dsfhub_data_source" "example_marklogic" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/mongodb.md
+++ b/examples/data_sources/mongodb.md
@@ -104,7 +104,6 @@ resource "dsfhub_data_source" "example_mongodb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/mongodb_atlas.md
+++ b/examples/data_sources/mongodb_atlas.md
@@ -80,7 +80,6 @@ resource "dsfhub_data_source" "example_mongodb_atlas" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/ms_sql_server.md
+++ b/examples/data_sources/ms_sql_server.md
@@ -84,7 +84,6 @@ resource "dsfhub_data_source" "example_ms_sql_server" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/mysql.md
+++ b/examples/data_sources/mysql.md
@@ -72,7 +72,6 @@ resource "dsfhub_data_source" "example_mysql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/neo4j.md
+++ b/examples/data_sources/neo4j.md
@@ -61,7 +61,6 @@ resource "dsfhub_data_source" "example_neo4j" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/netezza.md
+++ b/examples/data_sources/netezza.md
@@ -74,7 +74,6 @@ resource "dsfhub_data_source" "example_netezza" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/oracle.md
+++ b/examples/data_sources/oracle.md
@@ -130,7 +130,6 @@ resource "dsfhub_data_source" "example_oracle" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/percona_mongodb.md
+++ b/examples/data_sources/percona_mongodb.md
@@ -99,7 +99,6 @@ resource "dsfhub_data_source" "example_percona_mongodb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/percona_mysql.md
+++ b/examples/data_sources/percona_mysql.md
@@ -72,7 +72,6 @@ resource "dsfhub_data_source" "example_percona_mysql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/postgresql.md
+++ b/examples/data_sources/postgresql.md
@@ -80,7 +80,6 @@ resource "dsfhub_data_source" "example_postgresql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/progress_openedge.md
+++ b/examples/data_sources/progress_openedge.md
@@ -77,7 +77,6 @@ resource "dsfhub_data_source" "example_progress_openedge" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/redis.md
+++ b/examples/data_sources/redis.md
@@ -76,7 +76,6 @@ resource "dsfhub_data_source" "example_redis" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/sap_hana.md
+++ b/examples/data_sources/sap_hana.md
@@ -76,7 +76,6 @@ resource "dsfhub_data_source" "example_sap_hana" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/scylladb.md
+++ b/examples/data_sources/scylladb.md
@@ -73,7 +73,6 @@ resource "dsfhub_data_source" "example_scylladb" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/snowflake.md
+++ b/examples/data_sources/snowflake.md
@@ -141,7 +141,6 @@ resource "dsfhub_data_source" "example_snowflake" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/splunk.md
+++ b/examples/data_sources/splunk.md
@@ -88,7 +88,6 @@ resource "dsfhub_data_source" "example_splunk" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/sybase.md
+++ b/examples/data_sources/sybase.md
@@ -107,7 +107,6 @@ resource "dsfhub_data_source" "example_sybase" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/teradata.md
+++ b/examples/data_sources/teradata.md
@@ -79,7 +79,6 @@ resource "dsfhub_data_source" "example_teradata" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/yarn.md
+++ b/examples/data_sources/yarn.md
@@ -71,7 +71,6 @@ resource "dsfhub_data_source" "example_yarn" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/yugabyte_cql.md
+++ b/examples/data_sources/yugabyte_cql.md
@@ -77,7 +77,6 @@ resource "dsfhub_data_source" "example_yugabyte_cql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/data_sources/yugabyte_sql.md
+++ b/examples/data_sources/yugabyte_sql.md
@@ -78,7 +78,6 @@ resource "dsfhub_data_source" "example_yugabyte_sql" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/examples/log_aggregators/aws_s3.md
+++ b/examples/log_aggregators/aws_s3.md
@@ -47,9 +47,9 @@ resource "dsfhub_log_aggregator" "example_aws_s3" {
 	# max_concurrent_conn = var.max_concurrent_conn	# Maximum number of concurrent connections that sensitive data management should use at once.
 	# owned_by = var.owned_by	# Email of Owner / person responsible for the asset; can be different from the person in the managed_by field. Defaults to admin_email.
 	# parent_asset_id = var.parent_asset_id	# The name of an asset that this asset is part of (/related to). E.g. an AWS resource will generally have an AWS account asset as its parent. Also used to connect some log aggregating asset with the sources of their logs. E.g. An AWS LOG GROUP asset can have an AWS RDS as its parent, indicating that that is the log group for that RDS.
-	# provider = "aws-rds-mssql"	# The type of AWS RDS instance that the S3 asset is receiving audit logs from
 	# proxy = var.proxy	# 
 	# region = var.region	# For cloud systems with regions, the default region or region used with this asset
+	# s3_provider = "aws-rds-mssql"	# The type of AWS RDS instance that the S3 asset is receiving audit logs from. Accepted value: \"aws-rds-mssql\", required only for AWS RDS MS SQL SERVER auditing workflow.
 	# sdm_enabled = var.sdm_enabled	# Sensitive data management (SDM) is enabled if this parameter is set to True.
 	# service_endpoint = var.service_endpoint	# Specify a particular endpoint for a given service
 	# ssl = var.ssl	# 

--- a/website/docs/r/data_source.md
+++ b/website/docs/r/data_source.md
@@ -162,7 +162,6 @@ resource "dsfhub_data_source" "aws_rds_mysql_password" {
 
 ### Optional
 
-- `ad_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from
 - `asset_connection` (Block Set) N/A (see [below for nested schema](#nestedblock--asset_connection))
 - `asset_source` (String) The source platform/vendor/system of the asset data. Usually the service responsible for creating that asset document
 - `audit_info` (Block Set) Normally auto-populated when enabling the audit policy, it is a sub-document in JSON format containing configuration information for audit management. See documentation for values that can be added manually depending on asset type. Editing this value does NOT enable the audit policy. (see [below for nested schema](#nestedblock--audit_info))

--- a/website/docs/r/log_aggregator.md
+++ b/website/docs/r/log_aggregator.md
@@ -102,6 +102,7 @@ resource "dsfhub_log_aggregator" "example_aws_log_group_default" {
 - `project` (String) Project separates different resources of multiple users and control access to specific resources
 - `proxy` (String) Proxy to use for AWS calls if aws_proxy_config is populated the proxy field will get populated from the http value there
 - `region` (String) For cloud systems with regions, the default region or region used with this asset
+- `s3_provider` (String) The type of AWS RDS instance that the S3 asset is receiving audit logs from. Accepted value: \"aws-rds-mssql\", required only for AWS RDS MS SQL SERVER auditing workflow.
 - `server_host_name` (String) Hostname (or IP if name is unknown)
 - `server_ip` (String) IP address of the service where this asset is located. If no IP is available populate this field with other information that would identify the system e.g. hostname or AWS ARN, etc.
 - `server_port` (String) Port used by the source server


### PR DESCRIPTION
Closes https://onejira.imperva.com/browse/SCV-2784 

- Creates an `s3_provider` field for AWS S3 assets to support webgateway pulls for SQL Server data
- Removes unused `ad_provider` references from docs (believe that was Brian's attempt to do a similar thing)
