### PR TITLE
[SCV-2832] Consolidate connect/disconnect gateway logic

### DIFF
--- a/dsfhub/resource_common.go
+++ b/dsfhub/resource_common.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"reflect"
 	"strings"
+	"time"
 )
 
 func createResource(dsfDataSource *ResourceWrapper, serverType string, d *schema.ResourceData) {
@@ -393,6 +394,73 @@ func contains(l []string, x string) bool {
 		}
 	}
 	return false
+}
+
+func connectDisconnectGateway(d *schema.ResourceData, dsfDataSource ResourceWrapper, m interface{}) error {
+	// func connectDisconnectGateway(d *schema.ResourceData, dsfDataSource ResourceWrapper, m interface{}) {
+	client := m.(*Client)
+
+	// give enough time for connect/disconnect gateway playbook to complete
+	wait := 6 * time.Second
+
+	assetId := d.Get("asset_id").(string)
+	auditPullEnabled := d.Get("audit_pull_enabled").(bool)
+	auditType := d.Get("audit_type").(string)
+	auditPullEnabledChanged := d.HasChange("audit_pull_enabled")
+	auditTypeChanged := d.HasChange("audit_type")
+
+	log.Printf("[DEBUG] connectDisconnectGateway - assetId: %v", assetId)
+	log.Printf("[DEBUG] connectDisconnectGateway - auditPullEnabled: %v", auditPullEnabled)
+	log.Printf("[DEBUG] connectDisconnectGateway - auditType: %v", auditType)
+	log.Printf("[DEBUG] connectDisconnectGateway - auditPullEnabledChanged: %v", auditPullEnabledChanged)
+	log.Printf("[DEBUG] connectDisconnectGateway - auditTypeChanged: %v", auditTypeChanged)
+
+	// if audit_pull_enabled has been changed, connect/disconnect from gateway as needed
+	if auditPullEnabledChanged {
+		if auditPullEnabled {
+			// connect gateway
+			_, err := client.EnableAuditDSFDataSource(assetId)
+			if err != nil {
+				log.Printf("[INFO] Error enabling audit for assetId: %s\n", assetId)
+				return err
+			}
+			time.Sleep(wait)
+
+			// disconnect gateway
+		} else {
+			_, err := client.DisableAuditDSFDataSource(assetId)
+			if err != nil {
+				log.Printf("[INFO] Error disabling audit for assetId: %s\n", assetId)
+				return err
+			}
+			time.Sleep(wait)
+		}
+		// if asset is already connected, check whether relevant fields have been updated and reconnect to gateway
+	} else if auditPullEnabled {
+		if auditTypeChanged {
+			origAuditType, newAuditType := d.GetChange("audit_type")
+			log.Printf("[INFO] auditType value has changed from %s to %s, reconnecting asset to gateway\n", origAuditType, newAuditType)
+
+			// disconnect
+			_, err1 := client.DisableAuditDSFDataSource(assetId)
+			if err1 != nil {
+				log.Printf("[INFO] Error disabling audit for assetId: %s\n", assetId)
+				return err1
+			}
+			time.Sleep(wait)
+
+			// reconnect
+			_, err2 := client.EnableAuditDSFDataSource(assetId)
+			if err2 != nil {
+				log.Printf("[INFO] Error enabling audit for assetId: %s\n", assetId)
+				return err2
+			}
+			time.Sleep(wait)
+		}
+	} else {
+		log.Printf("[INFO] Asset %s does not need to be connected to or disconnected from gateway", assetId)
+	}
+	return nil
 }
 
 // ConnectionData resource hash functions

--- a/dsfhub/resource_data_source.go
+++ b/dsfhub/resource_data_source.go
@@ -3,10 +3,10 @@ package dsfhub
 import (
 	"bytes"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
-	"time"
 )
 
 func resourceDSFDataSource() *schema.Resource {
@@ -94,7 +94,8 @@ func resourceDSFDataSource() *schema.Resource {
 				Description: "If true, sonargateway will collect the audit logs for this system if it can.",
 				Required:    false,
 				Optional:    true,
-				Default:     false,
+				Computed:    true,
+				Default:     nil,
 			},
 			// "audit_state": {
 			// 	Type:         schema.TypeString,
@@ -1303,6 +1304,7 @@ func resourceDSFDataSourceCreate(d *schema.ResourceData, m interface{}) error {
 	dsfDataSource := ResourceWrapper{}
 	serverType := d.Get("server_type").(string)
 	createResource(&dsfDataSource, serverType, d)
+	// auditPullEnabled set to false as connect/disconnect logic handled below
 	dsfDataSource.Data.AssetData.AuditPullEnabled = false
 	log.Printf("[INFO] Creating DSF data source for serverType: %s and gatewayId: %s \n", dsfDataSource.Data.ServerType, dsfDataSource.Data.GatewayID)
 	dsfDataSourceResponse, err := client.CreateDSFDataSource(dsfDataSource)
@@ -1312,33 +1314,12 @@ func resourceDSFDataSourceCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
+	// Connect/disconnect asset to gateway
+	connectDisconnectGateway(d, dsfDataSource, m)
+
+	// Set ID
 	dsfDataSourceId := dsfDataSourceResponse.Data.AssetData.AssetID
 	d.SetId(dsfDataSourceId)
-
-	auditPullEnabled := d.Get("audit_pull_enabled").(bool)
-	if auditPullEnabled == true {
-		wait := 6 * time.Second
-		log.Printf("[INFO] Disabling and enabling audit for DSF data source dsfDataSourceId: %s and gatewayId: %s \n", dsfDataSourceId, dsfDataSource.Data.GatewayID)
-		_, err1 := client.DisableAuditDSFDataSource(dsfDataSourceId)
-		if err1 != nil {
-			log.Printf("[INFO] Error disabling audit for dsfDataSourceId: %s\n", dsfDataSourceId)
-			return err1
-		}
-		time.Sleep(wait)
-		_, err2 := client.EnableAuditDSFDataSource(dsfDataSourceId)
-		if err2 != nil {
-			log.Printf("[INFO] Error enabling audit for dsfDataSourceId: %s\n", dsfDataSourceId)
-			return err2
-		}
-		time.Sleep(wait)
-	} else if auditPullEnabled == false {
-		log.Printf("[INFO] Disabling DSF data source for serverType: %s and gatewayId: %s \n", dsfDataSource.Data.ServerType, dsfDataSource.Data.GatewayID)
-		_, err := client.DisableAuditDSFDataSource(dsfDataSourceId)
-		if err != nil {
-			log.Printf("[INFO] Error disabling audit for dsfDataSourceId: %s\n", dsfDataSourceId)
-			return err
-		}
-	}
 
 	// Set the rest of the state from the resource read
 	return resourceDSFDataSourceRead(d, m)
@@ -1646,7 +1627,6 @@ func resourceDSFDataSourceUpdate(d *schema.ResourceData, m interface{}) error {
 	dsfDataSource := ResourceWrapper{}
 	serverType := d.Get("server_type").(string)
 	createResource(&dsfDataSource, serverType, d)
-	dsfDataSource.Data.AssetData.AuditPullEnabled = false
 
 	log.Printf("[INFO] Updating DSF data source for serverType: %s and gatewayId: %s assetId: %s\n", dsfDataSource.Data.ServerType, dsfDataSource.Data.GatewayID, dsfDataSource.Data.AssetData.AssetID)
 	_, err := client.UpdateDSFDataSource(dsfDataSourceId, dsfDataSource)
@@ -1656,32 +1636,11 @@ func resourceDSFDataSourceUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.SetId(dsfDataSourceId)
+	// Connect/disconnect asset to gateway
+	connectDisconnectGateway(d, dsfDataSource, m)
 
-	auditPullEnabled := d.Get("audit_pull_enabled").(bool)
-	if auditPullEnabled == true {
-		wait := 6 * time.Second
-		log.Printf("[INFO] Disabling and enabling audit for DSF data source dsfDataSourceId: %s and gatewayId: %s \n", dsfDataSourceId, dsfDataSource.Data.GatewayID)
-		_, err1 := client.DisableAuditDSFDataSource(dsfDataSourceId)
-		if err1 != nil {
-			log.Printf("[INFO] Error disabling audit for dsfDataSourceId: %s\n", dsfDataSourceId)
-			return err1
-		}
-		time.Sleep(wait)
-		_, err2 := client.EnableAuditDSFDataSource(dsfDataSourceId)
-		if err2 != nil {
-			log.Printf("[INFO] Error enabling audit for dsfDataSourceId: %s\n", dsfDataSourceId)
-			return err2
-		}
-		time.Sleep(wait)
-	} else if auditPullEnabled == false {
-		log.Printf("[INFO] Disabling DSF data source for serverType: %s and gatewayId: %s \n", dsfDataSource.Data.ServerType, dsfDataSource.Data.GatewayID)
-		_, err := client.DisableAuditDSFDataSource(dsfDataSourceId)
-		if err != nil {
-			log.Printf("[INFO] Error disabling audit for dsfDataSourceId: %s\n", dsfDataSourceId)
-			return err
-		}
-	}
+	// Set ID
+	d.SetId(dsfDataSourceId)
 
 	// Set the rest of the state from the resource read
 	return resourceDSFDataSourceRead(d, m)

--- a/dsfhub/resource_log_aggregator.go
+++ b/dsfhub/resource_log_aggregator.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
-	"time"
 )
 
 func resourceLogAggregator() *schema.Resource {
@@ -623,7 +622,8 @@ func resourceLogAggregatorCreate(d *schema.ResourceData, m interface{}) error {
 	logAggregator := ResourceWrapper{}
 	serverType := d.Get("server_type").(string)
 	createResource(&logAggregator, serverType, d)
-
+	// auditPullEnabled set to false as connect/disconnect logic handled below
+	logAggregator.Data.AssetData.AuditPullEnabled = false
 	log.Printf("[INFO] Creating LogAggregator for serverType: %s and gatewayId: %s\n", logAggregator.Data.ServerType, logAggregator.Data.GatewayID)
 	createLogAggregatorResponse, err := client.CreateLogAggregator(logAggregator)
 
@@ -632,55 +632,12 @@ func resourceLogAggregatorCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
+	// Connect/disconnect asset to gateway
+	connectDisconnectGateway(d, logAggregator, m)
+
+	// Set ID
 	logAggregatorId := createLogAggregatorResponse.Data.ID
 	d.SetId(logAggregatorId)
-
-	auditPullEnabled := d.Get("audit_pull_enabled").(bool)
-	auditType := d.Get("audit_type").(string)
-	assetId := d.Get("asset_id").(string)
-	parentAssetId := d.Get("parent_asset_id")
-
-	if auditPullEnabled {
-		wait := 6 * time.Second
-
-		// if using one of slow_query audit types, enable audit on log aggregator
-		if contains(slowQueryAuditTypes, auditType) {
-			log.Printf("[INFO] Disabling and enabling audit for DSF data source assetId: %s \n", assetId)
-
-			_, err1 := client.DisableAuditDSFDataSource(assetId)
-			if err1 != nil {
-				log.Printf("[INFO] Error disabling audit for assetId: %s\n", assetId)
-				return err1
-			}
-			time.Sleep(wait)
-
-			_, err2 := client.EnableAuditDSFDataSource(assetId)
-			if err2 != nil {
-				log.Printf("[INFO] Error enabling audit for assetId: %s\n", assetId)
-				return err2
-			}
-			time.Sleep(wait)
-			// if not, enable audit against parent
-		} else if parentAssetId != nil {
-			parentAssetId := d.Get("parent_asset_id").(string)
-
-			log.Printf("[INFO] Disabling and enabling audit for DSF data source parentAssetId: %s \n", parentAssetId)
-			_, err1 := client.DisableAuditDSFDataSource(parentAssetId)
-			if err1 != nil {
-				log.Printf("[INFO] Error disabling audit for parentAssetId: %s\n", parentAssetId)
-				return err1
-			}
-			time.Sleep(wait)
-
-			_, err2 := client.EnableAuditDSFDataSource(parentAssetId)
-			if err2 != nil {
-				log.Printf("[INFO] Error enabling audit for parentAssetId: %s\n", parentAssetId)
-				return err2
-			}
-			time.Sleep(wait)
-		}
-
-	}
 
 	// Set the rest of the state from the resource read
 	return resourceLogAggregatorRead(d, m)
@@ -700,7 +657,7 @@ func resourceLogAggregatorRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if logAggregatorReadResponse != nil {
-		log.Printf("[INFO] Reading CloudAcount with logAggregatorId: %s | err: %s\n", logAggregatorId, err)
+		log.Printf("[INFO] Reading LogAggregator with logAggregatorId: %s | err: %s\n", logAggregatorId, err)
 	}
 
 	log.Printf("[DEBUG] logAggregatorReadResponse: %s\n", logAggregatorReadResponse.Data.ID)
@@ -855,6 +812,10 @@ func resourceLogAggregatorUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
+	// Connect/disconnect asset to gateway
+	connectDisconnectGateway(d, logAggregator, m)
+
+	// Set ID
 	d.SetId(logAggregatorId)
 
 	// Set the rest of the state from the resource read

--- a/dsfhub/resource_log_aggregator_schema.go
+++ b/dsfhub/resource_log_aggregator_schema.go
@@ -161,9 +161,3 @@ var requiredLogAggregatorJson = `{
 		}
 	}
 }`
-
-var slowQueryAuditTypes = []string{
-	"AWS_RDS_AURORA_MYSQL_SLOW",
-	"AWS_RDS_MYSQL_SLOW",
-	"AWS_NEPTUNE_SLOW",
-}


### PR DESCRIPTION
Sets `audit_pull_enabled` to be a computed value, and consolidates the "connect/disconnect" gateway logic across data sources and log aggregators.